### PR TITLE
Introduced NuGet CPM feature and Shared Toolkit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Join me on [**Developer Thoughts**](https://egvijayanand.in/), an exclusive blog
 
 |NuGet|VS Marketplace|
 |:---:|:---:|
-|[![VijayAnand.FormsTemplates - NuGet Package](https://badgen.net/nuget/v/VijayAnand.FormsTemplates/?icon=nuget)](https://www.nuget.org/packages/VijayAnand.FormsTemplates/)|[![Xamarin.Forms Project and Item Templates - VS Marketplace](https://badgen.net/vs-marketplace/v/egvijayanand.xamarin-forms-templates?icon=visualstudio)](https://marketplace.visualstudio.com/items?itemName=egvijayanand.xamarin-forms-templates)|
+|[![VijayAnand.FormsTemplates - NuGet Package](https://badgen.net/nuget/v/VijayAnand.FormsTemplates/?icon=nuget)](https://www.nuget.org/packages/VijayAnand.FormsTemplates/)|[![Xamarin.Forms Project and Item Templates - VS Marketplace](https://badgen.net/vs-marketplace/v/egvijayanand.xamarin-forms-templates?icon=visualstudio&foo=bar)](https://marketplace.visualstudio.com/items?itemName=egvijayanand.xamarin-forms-templates)|
 
 #### Access within Visual Studio IDE
 
@@ -47,15 +47,17 @@ dotnet new update
 
 Project template for Xamarin.Forms Class Library and is named as `formsclasslib`
 
-Class library project template take the below optional parameters to override its target framework and to include the officially supported [Xamarin.CommunityToolkit](https://www.nuget.org/packages/Xamarin.CommunityToolkit), [Xamarin.CommunityToolkit.Markup](https://www.nuget.org/packages/Xamarin.CommunityToolkit.Markup), [Xamarin.Essentials](https://www.nuget.org/packages/Xamarin.Essentials), [CommunityToolkit.Mvvm](https://www.nuget.org/packages/CommunityToolkit.Mvvm) (aka Microsoft MVVM Toolkit) or all NuGet packages:
+Class library project template take the below optional parameters to override its target framework and to include the officially supported [Xamarin.CommunityToolkit](https://www.nuget.org/packages/Xamarin.CommunityToolkit), [Xamarin.CommunityToolkit.Markup](https://www.nuget.org/packages/Xamarin.CommunityToolkit.Markup), [Xamarin.Essentials](https://www.nuget.org/packages/Xamarin.Essentials), [CommunityToolkit.Mvvm](https://www.nuget.org/packages/CommunityToolkit.Mvvm) (aka Microsoft MVVM Toolkit), [VijayAnand.Toolkit.Markup](https://www.nuget.org/packages/VijayAnand.Toolkit.Markup) (the Shared Toolkit) or all NuGet packages:
 
 * `-f` | `--framework` - Default value is `netstandard2.0`
+* `-asp` | `--all-supported-packages` - Default value is `false`
 * `-it` | `--include-toolkit` - Default value is `false`
 * `-im` | `--include-markup` - Default value is `false`
 * `-ie` | `--include-essentials` - Default value is `false`
 * `-imt` | `--include-mvvm-toolkit` - Default value is `false`
+* `-ist` | `--include-shared-toolkit` - Default value is `false`
 
-*Note: The NuGet package version being added out-of-the-box are v2.0.x for the Xamarin Toolkit packages, v1.7.x for the Xamarin.Essentials package, and v8.1.0 for the MVVM Toolkit package.*
+*Note: The NuGet package version being added out-of-the-box are v2.0.x for the Xamarin Toolkit packages, v1.8.x for the Xamarin.Essentials package, and v8.2.x for the MVVM Toolkit package.*
 
 |Item|Template Name|
 |:---:|:---:|
@@ -87,7 +89,18 @@ dotnet new formsclasslib -n MyApp.Core -f netstandard2.1
 ```
 Option to include NuGet packages:
 ```shell
-dotnet new formsclasslib -n MyApp.UI -it -im -ie -imt
+dotnet new formsclasslib -n MyApp.UI -it -im -ie -imt -ist
+```
+In a single parameter:
+```shell
+dotnet new formsclasslib -n MyApp.UI -asp
+```
+NuGet Central Package Management (CPM) feature:
+
+_For now, this is supported only on CLI. Can be used in combination with other parameters too._
+
+```shell
+dotnet new formsclasslib -n MyApp.UI -cpm
 ```
 
 Page:

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "rollForward": "latestMajor",
-    "version": "6.0.0"
+    "rollForward": "latestMinor",
+    "version": "8.0.100"
   }
 }

--- a/src/FormsTemplatesCLI/FormsClassLib/.template.config/ide.host.json
+++ b/src/FormsTemplatesCLI/FormsClassLib/.template.config/ide.host.json
@@ -3,6 +3,14 @@
     "icon": "ide/icon.png",
     "symbolInfo": [
         {
+            "id": "all-supported-packages",
+            "name": {
+                "text": "_Add all supported NuGet package reference"
+            },
+            "isVisible": true,
+            "defaultValue": "false"
+        },
+        {
             "id": "include-toolkit",
             "name": {
                 "text": "Add Xamarin.Community_Toolkit NuGet package reference"
@@ -30,6 +38,14 @@
             "id": "include-mvvm-toolkit",
             "name": {
                 "text": "Add CommunityToolkit.Mvvm (aka Microsoft MV_VM Toolkit) NuGet package reference"
+            },
+            "isVisible": true,
+            "defaultValue": "false"
+        },
+        {
+            "id": "include-shared-toolkit",
+            "name": {
+                "text": "Add and configure VijayAnand.Toolkit.Markup (_Shared) NuGet package reference"
             },
             "isVisible": true,
             "defaultValue": "false"

--- a/src/FormsTemplatesCLI/FormsClassLib/.template.config/template.json
+++ b/src/FormsTemplatesCLI/FormsClassLib/.template.config/template.json
@@ -21,7 +21,8 @@
         "type": "project"
     },
     "guids": [
-        "104D078F-F441-4A4A-A89B-21C40D7B8C10"
+        "104D078F-F441-4A4A-A89B-21C40D7B8C10",
+        "1D17E9ED-22F1-4992-AE45-B8507EFD6950"
     ],
     "symbols": {
         "Framework": {
@@ -42,6 +43,13 @@
             ],
             "replaces": "LIB_TFM",
             "defaultValue": "netstandard2.0"
+        },
+        "all-supported-packages": {
+            "type": "parameter",
+            "datatype": "bool",
+            "defaultValue": "false",
+            "description": "Option to add all supported NuGet package reference.",
+            "displayName": "_Add all supported NuGet package reference"
         },
         "include-toolkit": {
             "type": "parameter",
@@ -67,6 +75,20 @@
             "defaultValue": "false",
             "description": "If true, includes reference to the CommunityToolkit.Mvvm (aka Microsoft MVVM Toolkit) NuGet package."
         },
+        "include-shared-toolkit": {
+            "type": "parameter",
+            "datatype": "bool",
+            "defaultValue": "false",
+            "description": "Option to add VijayAnand.Toolkit.Markup NuGet package reference.",
+            "displayName": "Add VijayAnand.Toolkit.Markup NuGet package reference"
+        },
+        "central-pkg-mgmt": {
+            "type": "parameter",
+            "datatype": "bool",
+            "defaultValue": "false",
+            "description": "Option to configure NuGet Central Package Management (CPM).",
+            "displayName": "Option to configure NuGet Central Package Management (CPM)"
+        },
         "no-solution-file": {
             "type": "parameter",
             "datatype": "bool",
@@ -75,19 +97,27 @@
         },
         "AddToolkitPackage": {
             "type": "computed",
-            "value": "(include-toolkit)"
+            "value": "(include-toolkit || all-supported-packages)"
         },
         "AddMarkupPackage": {
             "type": "computed",
-            "value": "(include-markup)"
+            "value": "(include-markup || all-supported-packages)"
         },
         "AddEssentialsPackage": {
             "type": "computed",
-            "value": "(include-essentials)"
+            "value": "(include-essentials || all-supported-packages)"
         },
         "AddMvvmToolkitPackage": {
             "type": "computed",
-            "value": "(include-mvvm-toolkit)"
+            "value": "(include-mvvm-toolkit || all-supported-packages)"
+        },
+        "AddSharedToolkitPackage": {
+            "type": "computed",
+            "value": "(include-shared-toolkit || all-supported-packages)"
+        },
+        "CentralPkgMgmt": {
+            "type": "computed",
+            "value": "(central-pkg-mgmt)"
         },
         "HostIdentifier": {
             "type": "bind",
@@ -106,6 +136,12 @@
                     "condition": "(no-solution-file || !(HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
                     "exclude": [
                         "FormsClassLib.1.sln"
+                    ]
+                },
+                {
+                    "condition": "(!CentralPkgMgmt || !(HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
+                    "exclude": [
+                        "Directory.Packages.props"
                     ]
                 }
             ]

--- a/src/FormsTemplatesCLI/FormsClassLib/AssemblyInfo.cs
+++ b/src/FormsTemplatesCLI/FormsClassLib/AssemblyInfo.cs
@@ -1,8 +1,12 @@
+using Xamarin.Forms.Xaml;
+
+[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
+
 // For making use of C# 9.0 features such as Records.
 
 namespace System.Runtime.CompilerServices
 {
-    public class IsExternalInit
+    internal class IsExternalInit
     {
 
     }

--- a/src/FormsTemplatesCLI/FormsClassLib/Directory.Packages.props
+++ b/src/FormsTemplatesCLI/FormsClassLib/Directory.Packages.props
@@ -1,0 +1,23 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="Xamarin.Forms" Version="5.0.0.2622" />
+        <!--#if (AddEssentialsPackage)-->
+        <PackageVersion Include="Xamarin.Essentials" Version="1.8.0" />
+        <!--#endif-->
+        <!--#if (AddToolkitPackage)-->
+        <PackageVersion Include="Xamarin.CommunityToolkit" Version="2.0.6" />
+        <!--#endif-->
+        <!--#if (AddMarkupPackage)-->
+        <PackageVersion Include="Xamarin.CommunityToolkit.Markup" Version="2.0.6" />
+        <!--#endif-->
+        <!--#if (AddMvvmToolkitPackage)-->
+        <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+        <!--#endif-->
+        <!--#if (AddSharedToolkitPackage)-->
+        <PackageVersion Include="VijayAnand.Toolkit.Markup" Version="3.0.0" />
+        <!--#endif-->
+    </ItemGroup>
+</Project>

--- a/src/FormsTemplatesCLI/FormsClassLib/FormsClassLib.1.csproj
+++ b/src/FormsTemplatesCLI/FormsClassLib/FormsClassLib.1.csproj
@@ -9,18 +9,40 @@
         <RootNamespace>FormsClassLib._1</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.Forms" Version="5.0.0.*"/>
+        <!--#if (CentralPkgMgmt)-->
+        <PackageReference Include="Xamarin.Forms" />
         <!--#if (AddToolkitPackage)-->
-        <PackageReference Include="Xamarin.CommunityToolkit" Version="2.0.*" />
+        <PackageReference Include="Xamarin.CommunityToolkit" />
         <!--#endif-->
         <!--#if (AddMarkupPackage)-->
-        <PackageReference Include="Xamarin.CommunityToolkit.Markup" Version="2.0.*" />
+        <PackageReference Include="Xamarin.CommunityToolkit.Markup" />
         <!--#endif-->
         <!--#if (AddEssentialsPackage)-->
-        <PackageReference Include="Xamarin.Essentials" Version="1.8.*" />
+        <PackageReference Include="Xamarin.Essentials" />
         <!--#endif-->
         <!--#if (AddMvvmToolkitPackage)-->
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.*" />
+        <PackageReference Include="CommunityToolkit.Mvvm" />
+        <!--#endif-->
+        <!--#if (AddSharedToolkitPackage)-->
+        <PackageReference Include="VijayAnand.Toolkit.Markup" />
+        <!--#endif-->
+        <!--#else-->
+        <PackageReference Include="Xamarin.Forms" Version="5.*" />
+        <!--#if (AddToolkitPackage)-->
+        <PackageReference Include="Xamarin.CommunityToolkit" Version="2.*" />
+        <!--#endif-->
+        <!--#if (AddMarkupPackage)-->
+        <PackageReference Include="Xamarin.CommunityToolkit.Markup" Version="2.*" />
+        <!--#endif-->
+        <!--#if (AddEssentialsPackage)-->
+        <PackageReference Include="Xamarin.Essentials" Version="1.*" />
+        <!--#endif-->
+        <!--#if (AddMvvmToolkitPackage)-->
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
+        <!--#endif-->
+        <!--#if (AddSharedToolkitPackage)-->
+        <PackageReference Include="VijayAnand.Toolkit.Markup" Version="3.*" />
+        <!--#endif-->
         <!--#endif-->
     </ItemGroup>
 </Project>

--- a/src/FormsTemplatesCLI/FormsClassLib/FormsClassLib.1.sln
+++ b/src/FormsTemplatesCLI/FormsClassLib/FormsClassLib.1.sln
@@ -5,6 +5,13 @@ VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FormsClassLib.1", "FormsClassLib.1.csproj", "{104D078F-F441-4A4A-A89B-21C40D7B8C10}"
 EndProject
+#if (CentralPkgMgmt)
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1D17E9ED-22F1-4992-AE45-B8507EFD6950}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
+EndProject
+#endif
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/FormsTemplatesCLI/overview.md
+++ b/src/FormsTemplatesCLI/overview.md
@@ -2,15 +2,17 @@
 
 Project template for Xamarin.Forms Class Library and is named as `formsclasslib`
 
-Class library project template take the below optional parameters to override its target framework and to include the officially supported `Xamarin.CommunityToolkit`, `Xamarin.CommunityToolkit.Markup`, `Xamarin.Essentials`, `CommunityToolkit.Mvvm` (aka Microsoft MVVM Toolkit) or all NuGet packages:
+Class library project template take the below optional parameters to override its target framework and to include the officially supported `Xamarin.CommunityToolkit`, `Xamarin.CommunityToolkit.Markup`, `Xamarin.Essentials`, `CommunityToolkit.Mvvm` (aka Microsoft MVVM Toolkit), `VijayAnand.Toolkit.Markup` (the Shared Toolkit) or all NuGet packages:
 
 * `-f` | `--framework` - Default value is `netstandard2.0`
+* `-asp` | `--all-supported-packages` - Default value is `false`
 * `-it` | `--include-toolkit` - Default value is `false`
 * `-im` | `--include-markup` - Default value is `false`
 * `-ie` | `--include-essentials` - Default value is `false`
 * `-imt` | `--include-mvvm-toolkit` - Default value is `false`
+* `-ist` | `--include-shared-toolkit` - Default value is `false`
 
-*Note: The NuGet package version being added out-of-the-box are v2.0.x for the Xamarin Toolkit packages, v1.7.x for the Xamarin.Essentials package, and v8.1.0 for the MVVM Toolkit package.*
+*Note: The NuGet package version being added out-of-the-box are v2.0.x for the Xamarin Toolkit packages, v1.8.x for the Xamarin.Essentials package, and v8.2.x for the MVVM Toolkit package.*
 
 |Item|Template Name|
 |:---:|:---:|
@@ -56,7 +58,18 @@ dotnet new formsclasslib -n MyApp.Core -f netstandard2.1
 ```
 Option to include NuGet packages:
 ```shell
-dotnet new formsclasslib -n MyApp.UI -it -im -imt -ie
+dotnet new formsclasslib -n MyApp.UI -it -im -imt -ie -ist
+```
+In a single parameter:
+```shell
+dotnet new formsclasslib -n MyApp.UI -asp
+```
+NuGet Central Package Management (CPM) feature:
+
+_For now, this is supported only on CLI. Can be used in combination with other parameters too._
+
+```shell
+dotnet new formsclasslib -n MyApp.UI -cpm
 ```
 
 Page:

--- a/src/FormsTemplatesCLI/release-notes.txt
+++ b/src/FormsTemplatesCLI/release-notes.txt
@@ -8,13 +8,13 @@ What's new in ver. 1.5.0:
 
 dotnet new formsclasslib -o FormsLib -asp
 
-2. Option to reference Shared Toolkit NuGet package
+2. Option to reference the Shared Toolkit NuGet package
 
 -ist | --include-shared-toolkit -> The default value is false.
 
 dotnet new formsclasslib -o FormsLib -ist
 
-3. Introduced an option to support NuGet Central Package Management feature
+3. Introduced an option to support the NuGet Central Package Management (CPM) feature
 
 -cpm | --central-pkg-mgmt -> The default value is false.
 

--- a/src/FormsTemplatesCLI/release-notes.txt
+++ b/src/FormsTemplatesCLI/release-notes.txt
@@ -1,7 +1,29 @@
 Join me on Developer Thoughts (https://egvijayanand.in/), an exclusive blog for articles on Xamarin.Forms, .NET MAUI and Blazor.
 
-What's new in ver. 1.4.4:
+What's new in ver. 1.5.0:
 -------------------------
+1. Introduced an option to add a reference to all supported NuGet packages by specifying a single parameter
+
+-asp | --all-supported-packages -> The default value is false.
+
+dotnet new formsclasslib -o FormsLib -asp
+
+2. Option to reference Shared Toolkit NuGet package
+
+-ist | --include-shared-toolkit -> The default value is false.
+
+dotnet new formsclasslib -o FormsLib -ist
+
+3. Introduced an option to support NuGet Central Package Management feature
+
+-cpm | --central-pkg-mgmt -> The default value is false.
+
+dotnet new formsclasslib -o FormsLib -cpm
+
+Note: For now, the CPM feature is only supported on CLI.
+
+v1.4.4:
+
 Package versions bumped to pull the latest stable version.
 
 v1.4.3:


### PR DESCRIPTION
1. Introduced an option to add a reference to all supported NuGet packages by specifying a single parameter

`-asp` | `--all-supported-packages` -> The default value is `false`.

```shell
dotnet new formsclasslib -o FormsLib -asp
```
2. Option to reference the [Shared Toolkit](https://www.nuget.org/packages/VijayAnand.Toolkit.Markup) NuGet package

`-ist` | `--include-shared-toolkit` -> The default value is `false`.

```shell
dotnet new formsclasslib -o FormsLib -ist
```
3. Introduced an option to support the NuGet Central Package Management (CPM) feature

`-cpm` | `--central-pkg-mgmt` -> The default value is `false`.

```shell
dotnet new formsclasslib -o FormsLib -cpm
```

_Note: For now, the CPM feature is only supported on CLI._