### PR TITLE
Essentials Interfaces and Auto type inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dotnet new update
 
 #### Templates Included
 
-Project template for Xamarin.Forms Class Library and is named as `formsclasslib`
+Project template for Xamarin.Forms 5 Class Library and is named as `formsclasslib`
 
 Class library project template take the below optional parameters to override its target framework and to include the officially supported [Xamarin.CommunityToolkit](https://www.nuget.org/packages/Xamarin.CommunityToolkit), [Xamarin.CommunityToolkit.Markup](https://www.nuget.org/packages/Xamarin.CommunityToolkit.Markup), [Xamarin.Essentials](https://www.nuget.org/packages/Xamarin.Essentials), [CommunityToolkit.Mvvm](https://www.nuget.org/packages/CommunityToolkit.Mvvm) (aka Microsoft MVVM Toolkit), [VijayAnand.Toolkit.Markup](https://www.nuget.org/packages/VijayAnand.Toolkit.Markup) (the Shared Toolkit) or all NuGet packages:
 
@@ -56,6 +56,10 @@ Class library project template take the below optional parameters to override it
 * `-ie` | `--include-essentials` - Default value is `false`
 * `-imt` | `--include-mvvm-toolkit` - Default value is `false`
 * `-ist` | `--include-shared-toolkit` - Default value is `false`
+
+Explicit option:
+
+* `-iei` | `--include-essentials-interfaces` - Default value is `false`
 
 *Note: The NuGet package version being added out-of-the-box are v2.0.x for the Xamarin Toolkit packages, v1.8.x for the Xamarin.Essentials package, and v8.2.x for the MVVM Toolkit package.*
 
@@ -71,7 +75,41 @@ Class library project template take the below optional parameters to override it
 
 Use the below .NET CLI command to create the project, pages, and views out these templates:
 
-Here, `-n` denotes the name of the project/page/view that is to be created (for pages/views, don't need to suffix it with `.xaml` / `.cs`, it will be added automatically) (Can also be specified as `--name` in the expanded form).
+Class Library:
+
+```shell
+dotnet new formsclasslib -o MyApp.Core
+```
+
+Library target framework override:
+
+```shell
+dotnet new formsclasslib -o MyApp.Core -f netstandard2.1
+```
+
+Option to include NuGet packages:
+
+```shell
+dotnet new formsclasslib -o MyApp.UI -it -im -ie -iei -imt -ist
+```
+
+In a single parameter (Essentials Interfaces is an exception, to be explicitly mentioned):
+
+```shell
+dotnet new formsclasslib -o MyApp.UI -asp -iei
+```
+
+NuGet Central Package Management (CPM) feature:
+
+_For now, this is supported only on CLI. Can be used in combination with other parameters too._
+
+```shell
+dotnet new formsclasslib -o MyApp.UI -cpm
+```
+
+Here, `-n` denotes the name of the Page/View that is to be created (for Pages/Shell/Views, don't need to suffix the type like `HomePage`, `OrderView`, `AppShell` and file extension `.xaml` / `.cs`, it will be added automatically) (Can also be specified as `--name` in the expanded form).
+
+*Just mention only the name of the item that is to be created. Item Type and File Extension would be automatically added.*
 
 *Note: If name parameter is not provided, the .NET CLI template engine will take the current folder name in the context as its name.*
 
@@ -79,61 +117,43 @@ And `-na` denotes the namespace under which the file is to be created (Can also 
 
 *While working with .NET 7 or higher SDK, the namespace parameter in short notation needs to be passed as `-p:na` (i.e., it needs to be prefixed with `-p:`).*
 
-Class Library:
-```shell
-dotnet new formsclasslib -n MyApp.Core
-```
-Library target framework override:
-```shell
-dotnet new formsclasslib -n MyApp.Core -f netstandard2.1
-```
-Option to include NuGet packages:
-```shell
-dotnet new formsclasslib -n MyApp.UI -it -im -ie -imt -ist
-```
-In a single parameter:
-```shell
-dotnet new formsclasslib -n MyApp.UI -asp
-```
-NuGet Central Package Management (CPM) feature:
-
-_For now, this is supported only on CLI. Can be used in combination with other parameters too._
-
-```shell
-dotnet new formsclasslib -n MyApp.UI -cpm
-```
-
 Page:
+
 ```shell
-dotnet new forms-page -n LoginPage -na MyApp.Views
+dotnet new forms-page -n Login -na MyApp.Views
 ```
 ```shell
-dotnet new forms-page-cs -n HomePage -na MyApp.Views
+dotnet new forms-page-cs -n Home -na MyApp.Views
 ```
 
 View:
+
 ```shell
-dotnet new forms-view -n CardView -na MyApp.Views
+dotnet new forms-view -n Card -na MyApp.Views
 ```
 ```shell
-dotnet new forms-view-cs -n ContactsView -na MyApp.Views
+dotnet new forms-view-cs -n Order -na MyApp.Views
 ```
 
 Shell:
+
 ```shell
-dotnet new forms-shell -n AppShell -na MyApp
+dotnet new forms-shell -n App -na MyApp
 ```
 ```shell
-dotnet new forms-shell-cs -n MobileShell -na MyApp
+dotnet new forms-shell-cs -n Mobile -na MyApp
 ```
 
 Resource Dictionary:
 
 With C# code-behind file:
+
 ```shell
 dotnet new forms-resdict -n DefaultTheme -na MyApp.Themes
 ```
-Without C# code-behind file - Xaml only (Option can be specified as `-xo` or `--xaml-only`):
+
+Without C# code-behind file - Xaml only (The option to be specified is `-xo` or `--xaml-only`):
+
 ```shell
 dotnet new forms-resdict -n DarkTheme -na MyApp.Themes -xo
 ```

--- a/src/FormsTemplatesCLI/FormsClassLib/.template.config/ide.host.json
+++ b/src/FormsTemplatesCLI/FormsClassLib/.template.config/ide.host.json
@@ -35,6 +35,14 @@
             "defaultValue": "false"
         },
         {
+            "id": "include-essentials-interfaces",
+            "name": {
+                "text": "Add Xamarin.Essentials._Interfaces NuGet package reference"
+            },
+            "isVisible": true,
+            "defaultValue": "false"
+        },
+        {
             "id": "include-mvvm-toolkit",
             "name": {
                 "text": "Add CommunityToolkit.Mvvm (aka Microsoft MV_VM Toolkit) NuGet package reference"

--- a/src/FormsTemplatesCLI/FormsClassLib/.template.config/template.json
+++ b/src/FormsTemplatesCLI/FormsClassLib/.template.config/template.json
@@ -69,6 +69,12 @@
             "defaultValue": "false",
             "description": "If true, includes reference to the Xamarin.Essentials NuGet package."
         },
+        "include-essentials-interfaces": {
+            "type": "parameter",
+            "datatype": "bool",
+            "defaultValue": "false",
+            "description": "If true, includes reference to the Xamarin.Essentials.Interfaces NuGet package."
+        },
         "include-mvvm-toolkit": {
             "type": "parameter",
             "datatype": "bool",
@@ -95,23 +101,27 @@
             "defaultValue": "false",
             "description": "Option to skip creating a solution file."
         },
-        "AddToolkitPackage": {
+        "AddToolkit": {
             "type": "computed",
             "value": "(include-toolkit || all-supported-packages)"
         },
-        "AddMarkupPackage": {
+        "AddMarkup": {
             "type": "computed",
             "value": "(include-markup || all-supported-packages)"
         },
-        "AddEssentialsPackage": {
+        "AddEssentials": {
             "type": "computed",
             "value": "(include-essentials || all-supported-packages)"
         },
-        "AddMvvmToolkitPackage": {
+        "AddEssentialsInterfaces": {
+            "type": "computed",
+            "value": "(include-essentials-interfaces)"
+        },
+        "AddMvvmToolkit": {
             "type": "computed",
             "value": "(include-mvvm-toolkit || all-supported-packages)"
         },
-        "AddSharedToolkitPackage": {
+        "AddSharedToolkit": {
             "type": "computed",
             "value": "(include-shared-toolkit || all-supported-packages)"
         },

--- a/src/FormsTemplatesCLI/FormsClassLib/AssemblyInfo.cs
+++ b/src/FormsTemplatesCLI/FormsClassLib/AssemblyInfo.cs
@@ -6,8 +6,5 @@ using Xamarin.Forms.Xaml;
 
 namespace System.Runtime.CompilerServices
 {
-    internal class IsExternalInit
-    {
-
-    }
+    internal class IsExternalInit { }
 }

--- a/src/FormsTemplatesCLI/FormsClassLib/Class1.cs
+++ b/src/FormsTemplatesCLI/FormsClassLib/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace FormsClassLib._1
-{
-    public class Class1
-    {
-
-    }
-}

--- a/src/FormsTemplatesCLI/FormsClassLib/Directory.Packages.props
+++ b/src/FormsTemplatesCLI/FormsClassLib/Directory.Packages.props
@@ -4,20 +4,23 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="Xamarin.Forms" Version="5.0.0.2622" />
-        <!--#if (AddEssentialsPackage)-->
-        <PackageVersion Include="Xamarin.Essentials" Version="1.8.0" />
+        <!--#if (AddEssentials)-->
+        <PackageVersion Include="Xamarin.Essentials" Version="1.8.1" />
         <!--#endif-->
-        <!--#if (AddToolkitPackage)-->
+        <!--#if (AddEssentialsInterfaces)-->
+        <PackageVersion Include="Xamarin.Essentials.Interfaces" Version="1.8.0" />
+        <!--#endif-->
+        <!--#if (AddToolkit)-->
         <PackageVersion Include="Xamarin.CommunityToolkit" Version="2.0.6" />
         <!--#endif-->
-        <!--#if (AddMarkupPackage)-->
+        <!--#if (AddMarkup)-->
         <PackageVersion Include="Xamarin.CommunityToolkit.Markup" Version="2.0.6" />
         <!--#endif-->
-        <!--#if (AddMvvmToolkitPackage)-->
+        <!--#if (AddMvvmToolkit)-->
         <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
         <!--#endif-->
-        <!--#if (AddSharedToolkitPackage)-->
-        <PackageVersion Include="VijayAnand.Toolkit.Markup" Version="3.0.0" />
+        <!--#if (AddSharedToolkit)-->
+        <PackageVersion Include="VijayAnand.Toolkit.Markup" Version="3.2.0" />
         <!--#endif-->
     </ItemGroup>
 </Project>

--- a/src/FormsTemplatesCLI/FormsClassLib/FormsClassLib.1.csproj
+++ b/src/FormsTemplatesCLI/FormsClassLib/FormsClassLib.1.csproj
@@ -11,36 +11,42 @@
     <ItemGroup>
         <!--#if (CentralPkgMgmt)-->
         <PackageReference Include="Xamarin.Forms" />
-        <!--#if (AddToolkitPackage)-->
+        <!--#if (AddToolkit)-->
         <PackageReference Include="Xamarin.CommunityToolkit" />
         <!--#endif-->
-        <!--#if (AddMarkupPackage)-->
+        <!--#if (AddMarkup)-->
         <PackageReference Include="Xamarin.CommunityToolkit.Markup" />
         <!--#endif-->
-        <!--#if (AddEssentialsPackage)-->
+        <!--#if (AddEssentials)-->
         <PackageReference Include="Xamarin.Essentials" />
         <!--#endif-->
-        <!--#if (AddMvvmToolkitPackage)-->
+        <!--#if (AddEssentialsInterfaces)-->
+        <PackageReference Include="Xamarin.Essentials.Interfaces" />
+        <!--#endif-->
+        <!--#if (AddMvvmToolkit)-->
         <PackageReference Include="CommunityToolkit.Mvvm" />
         <!--#endif-->
-        <!--#if (AddSharedToolkitPackage)-->
+        <!--#if (AddSharedToolkit)-->
         <PackageReference Include="VijayAnand.Toolkit.Markup" />
         <!--#endif-->
         <!--#else-->
         <PackageReference Include="Xamarin.Forms" Version="5.*" />
-        <!--#if (AddToolkitPackage)-->
+        <!--#if (AddToolkit)-->
         <PackageReference Include="Xamarin.CommunityToolkit" Version="2.*" />
         <!--#endif-->
-        <!--#if (AddMarkupPackage)-->
+        <!--#if (AddMarkup)-->
         <PackageReference Include="Xamarin.CommunityToolkit.Markup" Version="2.*" />
         <!--#endif-->
-        <!--#if (AddEssentialsPackage)-->
+        <!--#if (AddEssentials)-->
         <PackageReference Include="Xamarin.Essentials" Version="1.*" />
         <!--#endif-->
-        <!--#if (AddMvvmToolkitPackage)-->
+        <!--#if (AddEssentialsInterfaces)-->
+        <PackageReference Include="Xamarin.Essentials.Interfaces" Version="1.*" />
+        <!--#endif-->
+        <!--#if (AddMvvmToolkit)-->
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
         <!--#endif-->
-        <!--#if (AddSharedToolkitPackage)-->
+        <!--#if (AddSharedToolkit)-->
         <PackageReference Include="VijayAnand.Toolkit.Markup" Version="3.*" />
         <!--#endif-->
         <!--#endif-->

--- a/src/FormsTemplatesCLI/FormsClassLib/HomePage.cs
+++ b/src/FormsTemplatesCLI/FormsClassLib/HomePage.cs
@@ -1,0 +1,54 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+#if (AddEssentials || AddEssentialsInterfaces)
+
+using Xamarin.Essentials;
+#endif
+#if AddEssentialsInterfaces
+using Xamarin.Essentials.Implementation;
+using Xamarin.Essentials.Interfaces;
+#endif
+#if AddToolkit
+
+using Xamarin.CommunityToolkit.Behaviors;
+using Xamarin.CommunityToolkit.Converters;
+using Xamarin.CommunityToolkit.Effects;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.CommunityToolkit.UI.Views;
+#endif
+#if AddMarkup
+
+using Xamarin.CommunityToolkit.Markup;
+#endif
+#if AddMvvmToolkit
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+#endif
+#if AddSharedToolkit
+
+using VijayAnand.Toolkit.Markup;
+#endif
+#if AddSharedToolkit
+
+// Static
+using static Xamarin.CommunityToolkit.Markup.GridRowsColumns;
+using static VijayAnand.Toolkit.Markup.ResourceHelper;
+using static VijayAnand.Toolkit.Markup.VisualStateHelper;
+#elif AddMarkup
+
+// Static
+using static Xamarin.CommunityToolkit.Markup.GridRowsColumns;
+#endif
+
+namespace FormsClassLib._1
+{
+    public class HomePage : ContentPage
+    {
+        public HomePage()
+        {
+            
+        }
+    }
+}

--- a/src/FormsTemplatesCLI/FormsPage/.template.config/template.json
+++ b/src/FormsTemplatesCLI/FormsPage/.template.config/template.json
@@ -22,7 +22,7 @@
             "path": "FormsPage.1.xaml"
         },
         {
-            "path": "FormsPage.1.xaml.cs",
+            "path": "FormsPage.1Page.xaml.cs",
             "condition": "(!XamlOnly)"
         }
     ],
@@ -54,7 +54,7 @@
                 {
                     "condition": "(XamlOnly)",
                     "exclude": [
-                        "FormsPage.1.xaml.cs"
+                        "FormsPage.1Page.xaml.cs"
                     ]
                 }
             ]

--- a/src/FormsTemplatesCLI/FormsPage/FormsPage.1Page.xaml
+++ b/src/FormsTemplatesCLI/FormsPage/FormsPage.1Page.xaml
@@ -10,7 +10,7 @@
     mc:Ignorable="d">
 <!--#else-->
 <ContentPage
-    x:Class="MyApp.Namespace.FormsPage__1"
+    x:Class="MyApp.Namespace.FormsPage__1Page"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"

--- a/src/FormsTemplatesCLI/FormsPage/FormsPage.1Page.xaml.cs
+++ b/src/FormsTemplatesCLI/FormsPage/FormsPage.1Page.xaml.cs
@@ -4,9 +4,9 @@ using Xamarin.Forms.Xaml;
 namespace MyApp.Namespace
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class FormsView__1 : ContentView
+    public partial class FormsPage__1Page : ContentPage
     {
-        public FormsView__1()
+        public FormsPage__1Page()
         {
             InitializeComponent();
         }

--- a/src/FormsTemplatesCLI/FormsPageCS/FormsPage.1Page.cs
+++ b/src/FormsTemplatesCLI/FormsPageCS/FormsPage.1Page.cs
@@ -2,9 +2,9 @@
 
 namespace MyApp.Namespace
 {
-    public partial class FormsPage__1 : ContentPage
+    public partial class FormsPage__1Page : ContentPage
     {
-        public FormsPage__1()
+        public FormsPage__1Page()
         {
             Content = new StackLayout()
             {

--- a/src/FormsTemplatesCLI/FormsShell/.template.config/template.json
+++ b/src/FormsTemplatesCLI/FormsShell/.template.config/template.json
@@ -22,7 +22,7 @@
             "path": "FormsShell.1.xaml"
         },
         {
-            "path": "FormsShell.1.xaml.cs",
+            "path": "FormsShell.1Shell.xaml.cs",
             "condition": "(!XamlOnly)"
         }
     ],
@@ -54,7 +54,7 @@
                 {
                     "condition": "(XamlOnly)",
                     "exclude": [
-                        "FormsShell.1.xaml.cs"
+                        "FormsShell.1Shell.xaml.cs"
                     ]
                 }
             ]

--- a/src/FormsTemplatesCLI/FormsShell/FormsShell.1Shell.xaml
+++ b/src/FormsTemplatesCLI/FormsShell/FormsShell.1Shell.xaml
@@ -10,7 +10,7 @@
     mc:Ignorable="d">
 <!--#else-->
 <Shell
-    x:Class="MyApp.Namespace.FormsShell__1"
+    x:Class="MyApp.Namespace.FormsShell__1Shell"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"

--- a/src/FormsTemplatesCLI/FormsShell/FormsShell.1Shell.xaml.cs
+++ b/src/FormsTemplatesCLI/FormsShell/FormsShell.1Shell.xaml.cs
@@ -4,9 +4,9 @@ using Xamarin.Forms.Xaml;
 namespace MyApp.Namespace
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class FormsShell__1 : Shell
+    public partial class FormsShell__1Shell : Shell
     {
-        public FormsShell__1()
+        public FormsShell__1Shell()
         {
             InitializeComponent();
         }

--- a/src/FormsTemplatesCLI/FormsShellCS/FormsShell.1Shell.cs
+++ b/src/FormsTemplatesCLI/FormsShellCS/FormsShell.1Shell.cs
@@ -2,9 +2,9 @@
 
 namespace MyApp.Namespace
 {
-    public partial class FormsShell__1 : Shell
+    public partial class FormsShell__1Shell : Shell
     {
-        public FormsShell__1()
+        public FormsShell__1Shell()
         {
             // Flyout Items
             //Items.Add(new FlyoutItem()

--- a/src/FormsTemplatesCLI/FormsView/.template.config/template.json
+++ b/src/FormsTemplatesCLI/FormsView/.template.config/template.json
@@ -22,7 +22,7 @@
             "path": "FormsView.1.xaml"
         },
         {
-            "path": "FormsView.1.xaml.cs",
+            "path": "FormsView.1View.xaml.cs",
             "condition": "(!XamlOnly)"
         }
     ],
@@ -54,7 +54,7 @@
                 {
                     "condition": "(XamlOnly)",
                     "exclude": [
-                        "FormsView.1.xaml.cs"
+                        "FormsView.1View.xaml.cs"
                     ]
                 }
             ]

--- a/src/FormsTemplatesCLI/FormsView/FormsView.1View.xaml
+++ b/src/FormsTemplatesCLI/FormsView/FormsView.1View.xaml
@@ -10,7 +10,7 @@
     mc:Ignorable="d">
 <!--#else-->
 <ContentView
-    x:Class="MyApp.Namespace.FormsView__1"
+    x:Class="MyApp.Namespace.FormsView__1View"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"

--- a/src/FormsTemplatesCLI/FormsView/FormsView.1View.xaml.cs
+++ b/src/FormsTemplatesCLI/FormsView/FormsView.1View.xaml.cs
@@ -4,9 +4,9 @@ using Xamarin.Forms.Xaml;
 namespace MyApp.Namespace
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class FormsPage__1 : ContentPage
+    public partial class FormsView__1View : ContentView
     {
-        public FormsPage__1()
+        public FormsView__1View()
         {
             InitializeComponent();
         }

--- a/src/FormsTemplatesCLI/FormsViewCS/FormsView.1View.cs
+++ b/src/FormsTemplatesCLI/FormsViewCS/FormsView.1View.cs
@@ -2,9 +2,9 @@
 
 namespace MyApp.Namespace
 {
-    public partial class FormsView__1 : ContentView
+    public partial class FormsView__1View : ContentView
     {
-        public FormsView__1()
+        public FormsView__1View()
         {
             Content = new StackLayout()
             {

--- a/src/FormsTemplatesCLI/overview.md
+++ b/src/FormsTemplatesCLI/overview.md
@@ -1,6 +1,6 @@
 ### CLI Project and Item Templates for developing Xamarin.Forms App that runs on iOS, Android, and Windows
 
-Project template for Xamarin.Forms Class Library and is named as `formsclasslib`
+Project template for Xamarin.Forms 5 Class Library and is named as `formsclasslib`
 
 Class library project template take the below optional parameters to override its target framework and to include the officially supported `Xamarin.CommunityToolkit`, `Xamarin.CommunityToolkit.Markup`, `Xamarin.Essentials`, `CommunityToolkit.Mvvm` (aka Microsoft MVVM Toolkit), `VijayAnand.Toolkit.Markup` (the Shared Toolkit) or all NuGet packages:
 
@@ -11,6 +11,10 @@ Class library project template take the below optional parameters to override it
 * `-ie` | `--include-essentials` - Default value is `false`
 * `-imt` | `--include-mvvm-toolkit` - Default value is `false`
 * `-ist` | `--include-shared-toolkit` - Default value is `false`
+
+Explicit option:
+
+* `-iei` | `--include-essentials-interfaces` - Default value is `false`
 
 *Note: The NuGet package version being added out-of-the-box are v2.0.x for the Xamarin Toolkit packages, v1.8.x for the Xamarin.Essentials package, and v8.2.x for the MVVM Toolkit package.*
 
@@ -41,7 +45,41 @@ dotnet new update
 
 Use the below .NET CLI command to create the project, pages, and views out these templates:
 
-Here, `-n` denotes the name of the project/page/view that is to be created (for pages/views, don't need to suffix it with `.xaml` / `.cs`, it will be added automatically) (Can also be specified as `--name` in the expanded form).
+```shell
+dotnet new formsclasslib -o MyApp.Core
+```
+
+Library target framework override:
+
+```shell
+dotnet new formsclasslib -o MyApp.Core -f netstandard2.1
+```
+
+Option to include NuGet packages:
+
+```shell
+dotnet new formsclasslib -o MyApp.UI -it -im -ie -iei -imt -ist
+```
+
+In a single parameter (Essentials Interfaces is an exception, to be explicitly mentioned):
+
+```shell
+dotnet new formsclasslib -o MyApp.UI -asp -iei
+```
+
+NuGet Central Package Management (CPM) feature:
+
+_For now, this is supported only on CLI. Can be used in combination with other parameters too._
+
+```shell
+dotnet new formsclasslib -o MyApp.UI -cpm
+```
+
+Item Template options:
+
+Here, `-n` denotes the name of the Page/View that is to be created (for Pages/Shell/Views, don't need to suffix the type like `HomePage`, `OrderView`, `AppShell` and file extension `.xaml` / `.cs`, it will be added automatically) (Can also be specified as `--name` in the expanded form).
+
+*Just mention only the name of the item that is to be created. Item Type and File Extension would be automatically added.*
 
 *Note: If name parameter is not provided, the .NET CLI template engine will take the current folder name in the context as its name.*
 
@@ -49,61 +87,43 @@ And `-na` denotes the namespace under which the file is to be created (Can also 
 
 *While working with .NET 7 or higher SDK, the namespace parameter in short notation needs to be passed as `-p:na` (i.e., it needs to be prefixed with `-p:`).*
 
-```shell
-dotnet new formsclasslib -n MyApp.Core
-```
-Library target framework override:
-```shell
-dotnet new formsclasslib -n MyApp.Core -f netstandard2.1
-```
-Option to include NuGet packages:
-```shell
-dotnet new formsclasslib -n MyApp.UI -it -im -imt -ie -ist
-```
-In a single parameter:
-```shell
-dotnet new formsclasslib -n MyApp.UI -asp
-```
-NuGet Central Package Management (CPM) feature:
-
-_For now, this is supported only on CLI. Can be used in combination with other parameters too._
-
-```shell
-dotnet new formsclasslib -n MyApp.UI -cpm
-```
-
 Page:
+
 ```shell
-dotnet new forms-page -n LoginPage -na MyApp.Views
+dotnet new forms-page -n Login -na MyApp.Views
 ```
 ```shell
-dotnet new forms-page-cs -n HomePage -na MyApp.Views
+dotnet new forms-page-cs -n Home -na MyApp.Views
 ```
 
 View:
+
 ```shell
-dotnet new forms-view -n CardView -na MyApp.Views
+dotnet new forms-view -n Card -na MyApp.Views
 ```
 ```shell
-dotnet new forms-view-cs -n ContactView -na MyApp.Views
+dotnet new forms-view-cs -n Order -na MyApp.Views
 ```
 
 Shell:
+
 ```shell
-dotnet new forms-shell -n AppShell -na MyApp
+dotnet new forms-shell -n App -na MyApp
 ```
 ```shell
-dotnet new forms-shell-cs -n MobileShell -na MyApp
+dotnet new forms-shell-cs -n Mobile -na MyApp
 ```
 
 Resource Dictionary:
 
 With C# code-behind file:
+
 ```shell
 dotnet new forms-resdict -n DefaultTheme -na MyApp.Themes
 ```
 
-Without C# code-behind file - Xaml only (Option can be specified as `-xo` or `--xaml-only`):
+Without C# code-behind file - Xaml only (The option to be specified is `-xo` or `--xaml-only`):
+
 ```shell
 dotnet new forms-resdict -n DarkTheme -na MyApp.Themes -xo
 ```

--- a/src/FormsTemplatesCLI/release-notes.txt
+++ b/src/FormsTemplatesCLI/release-notes.txt
@@ -2,9 +2,9 @@ Join me on Developer Thoughts (https://egvijayanand.in/), an exclusive blog for 
 
 What's new in ver. 1.6.0:
 -------------------------
-1. Introduced an option to add a reference to Xamarin.Essentials.Interfaces NuGet package, an explicit option.
+1. Introduced an option to add a reference to Xamarin.Essentials.Interfaces NuGet package, an explicit option
 
-2. Auto inclusion of the the Type of the Item template that is created for Page, Shell, and Views.
+2. Auto inclusion of the Type of the Item template that is created for Page, Shell, and Views
 
 Just mention only the name of the item that is to be created. Item Type and File Extension would be automatically added.
 

--- a/src/FormsTemplatesCLI/release-notes.txt
+++ b/src/FormsTemplatesCLI/release-notes.txt
@@ -1,7 +1,23 @@
 Join me on Developer Thoughts (https://egvijayanand.in/), an exclusive blog for articles on Xamarin.Forms, .NET MAUI and Blazor.
 
-What's new in ver. 1.5.0:
+What's new in ver. 1.6.0:
 -------------------------
+1. Introduced an option to add a reference to Xamarin.Essentials.Interfaces NuGet package, an explicit option.
+
+2. Auto inclusion of the the Type of the Item template that is created for Page, Shell, and Views.
+
+Just mention only the name of the item that is to be created. Item Type and File Extension would be automatically added.
+
+dotnet new forms-page -n Home -p:na MyApp.Views
+
+dotnet new forms-page-cs -n Settings -p:na MyApp.Views
+
+dotnet new forms-view -n Card -p:na MyApp.Views
+
+dotnet new forms-view-cs -n Order -p:na MyApp.Views
+
+v1.5.0:
+
 1. Introduced an option to add a reference to all supported NuGet packages by specifying a single parameter
 
 -asp | --all-supported-packages -> The default value is false.


### PR DESCRIPTION
* Introduced an option to add a reference to `Xamarin.Essentials.Interfaces` NuGet package, **an explicit option**
* Auto inclusion of the Type (and File Extension) of the Item template that is created for Page, Shell, and Views

_Just mention only the name of the item that is to be created. Item Type and File Extension would be automatically added._

```shell
dotnet new forms-page -n Home -p:na MyApp.Views
```
```shell
dotnet new forms-page-cs -n Settings -p:na MyApp.Views
```
```shell
dotnet new forms-view -n Card -p:na MyApp.Views
```
```shell
dotnet new forms-view-cs -n Order -p:na MyApp.Views
```